### PR TITLE
Fix #5 which prevents tool from running along with other cleanup

### DIFF
--- a/export_stars/export_stars.py
+++ b/export_stars/export_stars.py
@@ -30,8 +30,8 @@ def config_retry(backoff_factor=1.0, total=8):
 
 def parse_args():
     parser = ArgumentParser(description="export a GitHub user's starred repositorys to CSV")
-    parser.add_argument("--user")
-    parser.add_argument("--github-token")
+    parser.add_argument("--user", dest='user')
+    parser.add_argument("--github-token", dest='token')
     return parser.parse_args()
 
 

--- a/export_stars/export_stars.py
+++ b/export_stars/export_stars.py
@@ -28,16 +28,14 @@ def config_retry(backoff_factor=1.0, total=8):
     return Retry(total=total, backoff_factor=backoff_factor)
 
 
-def parse_args():
+def main():
     parser = ArgumentParser(description="export a GitHub user's starred repositories to CSV")
     parser.add_argument("--user", dest='user')
     parser.add_argument("--github-token", dest='token')
-    return parser.parse_args()
-
-
-def main():
-    args = parse_args()
+    args = parser.parse_args()
     if not args.user:
+        parser.print_usage()
+        print('')
         print("Please set `--user` to a valid GitHub user name.", file=sys.stderr)
         exit(1)
 

--- a/export_stars/export_stars.py
+++ b/export_stars/export_stars.py
@@ -29,7 +29,7 @@ def config_retry(backoff_factor=1.0, total=8):
 
 
 def parse_args():
-    parser = ArgumentParser(description="export a GitHub user's starred repositorys to CSV")
+    parser = ArgumentParser(description="export a GitHub user's starred repositories to CSV")
     parser.add_argument("--user", dest='user')
     parser.add_argument("--github-token", dest='token')
     return parser.parse_args()

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,19 @@
 This script exports a GitHub user's starred repositories (URL & description) to a CSV file.
 
-Usage: `GH_USER=defunkt python3 export_stars.py > stars.csv`
+Setup:
+
+    python -m pip install -i requirements.txt
+    pip install -i requirements.txt
+
+Usage:
+
+NOTE1 Under Microsoft Windows may need to set:
+
+    set PYTHONUTF8=1
+
+NOTE2 Can use without a token BUT if there are a lot of stars need a token to avoid `github.GithubException.RateLimitExceededException`
+
+    GH_USER=defunkt python3 export_stars/export_stars.py > stars.csv
+    python export_stars/export_stars.py --user defunkt > stars.csv
 
 Thanks to the authors of [PyGitHub](https://github.com/PyGithub/PyGithub) for the slick client library.

--- a/readme.md
+++ b/readme.md
@@ -2,8 +2,8 @@ This script exports a GitHub user's starred repositories (URL & description) to 
 
 Setup:
 
-    python -m pip install -i requirements.txt
-    pip install -i requirements.txt
+    python -m pip install -r requirements.txt
+    pip install -r requirements.txt
 
 Usage:
 


### PR DESCRIPTION
* Pulls in pchabermann's fix for #5 (from PR #6) which preserves existing parameter names
* Adopts the idea from micmalti's PR #7 to update readme
* Cleans up readme example so it works from a checkout, along with install notes and Windows notes
* Fixes #9 - along with improved usage errors

## Summary by Sourcery

Apply fixes for parameter name preservation (#5) and missing user error display (#9), streamline argument parsing in main(), and refresh README with installation and usage instructions including Windows and token notes.

Bug Fixes:
- Preserve existing argument names in parameter parsing (#5)
- Display usage and clearer error when `--user` is missing (#9)

Enhancements:
- Consolidate argument parsing into the main function to simplify setup and handling

Documentation:
- Add installation steps, Windows environment variable advice, token requirement warning, and checkout-friendly usage examples to README